### PR TITLE
Identify Jira ticket references in the commit body

### DIFF
--- a/src/rules.rs
+++ b/src/rules.rs
@@ -52,17 +52,25 @@ pub static ISSUE_NUMBER_REFERENCE: &str = r"
     (
         https?://[^\s]+/| # Match entire URL
         [\w\-_\.]+/[\w\-_\.]+[\#!]| # Repo shorthand format: org/repo#123 or org/repo!123
-        [\#!] # Only an issue or PR symbol
+        [\#!]| # Only an issue or PR symbol
+        [A-Z]{2,}- # Jira project keys, at least 2 uppercase character, e.g. AB-123
     )
     \d+ # Ends in an issue/PR number
 ";
 
+// Match all GitHub and GitLab keywords
+pub static FIX_KEY_WORD_REFERENCE: &str = r"
+    (fix(es|ed|ing)?|clos(e|es|ed|ing)|resolv(e|es|ed|ing)|implement(s|ed|ing)?) # Includes keyword
+    :? # Optional colon
+";
+
 lazy_static! {
-    // Match all GitHub and GitLab keywords
     pub static ref CONTAINS_FIX_TICKET: Regex = Regex::new(&format!(r"(?xi)
-        (fix(es|ed|ing)?|clos(e|es|ed|ing)|resolv(e|es|ed|ing)|implement(s|ed|ing)?) # Includes keyword
-        :? # Optional colon
-        \s+
+        {FIX_KEY_WORD_REFERENCE}\s+{ISSUE_NUMBER_REFERENCE}
+    ")).unwrap();
+
+    pub static ref CONTAINS_FIX_TICKET_OR_TICKET_REFERENCE: Regex = Regex::new(&format!(r"(?xi)
+        {FIX_KEY_WORD_REFERENCE}\s+{ISSUE_NUMBER_REFERENCE}|
         {ISSUE_NUMBER_REFERENCE}
     ")).unwrap();
 

--- a/src/rules/message_ticket_number.rs
+++ b/src/rules/message_ticket_number.rs
@@ -133,6 +133,7 @@ mod tests {
         assert_message_valid("Fixes org/repo#123");
         assert_message_valid("Fixed org/repo!123");
         assert_message_valid("Fixes https://website.om/org/repo/issues/123");
+        assert_message_valid("Fixes ABC-123");
     }
 
     #[test]
@@ -143,6 +144,7 @@ mod tests {
         assert_message_valid("Part of https://website.om/org/repo/issues/123");
         assert_message_valid("Part of org/repo#123");
         assert_message_valid("Part of org/repo!123");
+        assert_message_valid("Part of ABC-123");
         assert_message_valid("related #123");
         assert_message_valid("Related #123");
         assert_message_valid("Related: #123");
@@ -156,10 +158,12 @@ mod tests {
             assert_message_valid(&format!("Part of {}: #123", reference_type));
             assert_message_valid(&format!("part of {}: !123", reference_type));
             assert_message_valid(&format!("Part of {}: !123", reference_type));
+            assert_message_valid(&format!("Part of {}: ABC-123", reference_type));
             assert_message_valid(&format!("part of {} #123", reference_type));
             assert_message_valid(&format!("Part of {} #123", reference_type));
             assert_message_valid(&format!("part of {} !123", reference_type));
             assert_message_valid(&format!("Part of {} !123", reference_type));
+            assert_message_valid(&format!("Part of {} ABC-123", reference_type));
         }
     }
 

--- a/src/rules/subject_ticket_number.rs
+++ b/src/rules/subject_ticket_number.rs
@@ -1,5 +1,4 @@
 use core::ops::Range;
-use regex::Regex;
 
 use crate::commit::Commit;
 use crate::issue::{Context, Issue, Position};
@@ -7,14 +6,7 @@ use crate::rule::Rule;
 use crate::rule::RuleValidator;
 use crate::utils::character_count_for_bytes_index;
 
-use crate::rules::CONTAINS_FIX_TICKET;
-
-lazy_static! {
-    // Jira project keys are at least 2 uppercase characters long.
-    // AB-123
-    // JIRA-123
-    static ref SUBJECT_WITH_TICKET: Regex = Regex::new(r"[A-Z]{2,}-\d+").unwrap();
-}
+use crate::rules::CONTAINS_FIX_TICKET_OR_TICKET_REFERENCE;
 
 pub struct SubjectTicketNumber {}
 
@@ -28,7 +20,8 @@ impl RuleValidator<Commit> for SubjectTicketNumber {
     fn validate(&self, commit: &Commit) -> Option<Vec<Issue>> {
         let mut issues = vec![];
         let subject = &commit.subject.to_string();
-        if let Some(captures) = SUBJECT_WITH_TICKET.captures(subject) {
+
+        if let Some(captures) = CONTAINS_FIX_TICKET_OR_TICKET_REFERENCE.captures(subject) {
             match captures.get(0) {
                 Some(capture) => issues.push(add_subject_ticket_number_error(commit, capture)),
                 None => {
@@ -38,15 +31,6 @@ impl RuleValidator<Commit> for SubjectTicketNumber {
                 }
             };
         }
-        if let Some(captures) = CONTAINS_FIX_TICKET.captures(subject) {
-            match captures.get(0) {
-                Some(capture) => issues.push(add_subject_ticket_number_error(commit, capture)),
-                None => {
-                    error!("SubjectTicketNumber: Unable to fetch issue number match from subject.");
-                }
-            };
-        }
-
         if issues.is_empty() {
             None
         } else {
@@ -116,17 +100,11 @@ mod tests {
         let subjects = vec![
             "This is a normal commit",
             "Fix #", // Not really good subjects, but won't fail on this rule
-            "Fix ##123",
             "Fix #a123",
             "Fix !",
-            "Fix !!123",
             "Fix !a123",
             "Fix /123",                                   // No org/repo format
             "Fix repo/123",                               // Missing org
-            "Fix repo#123",                               // Missing org
-            "Fix repo!123",                               // Missing org
-            "Fix https://website.om/org/repo/issues#123", // No full format with only slashes
-            "Fix https://website.om/org/repo/issues!123", // No full format with only slashes
             "Change A-1 config",
             "Change A-12 config",
         ];
@@ -208,15 +186,15 @@ mod tests {
     fn jira_ticket_number() {
         let issue = first_issue(validate(&commit("Fix JIRA-123 about email validation", "")));
         assert_eq!(issue.message, "The subject contains a ticket number");
-        assert_eq!(issue.position, subject_position(5));
+        assert_eq!(issue.position, subject_position(1));
         assert_contains_issue_output(
             &issue,
             "1 | Fix JIRA-123 about email validation\n\
-               |     -------- Remove the ticket number from the subject\n\
+               | ------------ Remove the ticket number from the subject\n\
               ~~~\n\
              3 | \n\
-             4 | JIRA-123\n\
-               | ++++++++ Move the ticket number to the message body",
+             4 | Fix JIRA-123\n\
+               | ++++++++++++ Move the ticket number to the message body",
         );
     }
 
@@ -304,6 +282,6 @@ mod tests {
     #[test]
     fn multiple_issues() {
         let issues = validate(&commit("Fix #123 JIRA-123", "")).expect("No issues");
-        assert_eq!(issues.len(), 2);
+        assert_eq!(issues.len(), 1);
     }
 }


### PR DESCRIPTION
Identify Jira ticket references in the commit body, e.g. recognise "Fix ABC-123" or "Implements ABC-123" as valid ticket references in the commit body.

While Rules/SubjectTicketNumber identifies Jira ticket references like "ABC-123", Rules/MessageTicketNumber keeps throwing hints even if "Fix ABC" is present in the commit body.

For example, for a commit like:

    ABC-123: Identify Jira issue references

    Identify Jira issue references in the commit body.

Lintje outputs:

    Error[SubjectTicketNumber]: The subject contains a ticket number
    65ee0ed:1:1: ABC-123: Identify Jira issue references
      |
    1 | ABC-123: Identify Jira issue references
      | ------- Remove the ticket number from the subject
     ~~~
    4 |
    5 | ABC-123
      | +++++++ Move the ticket number to the message body
      |
      = help: https://r.lintje.dev/r/SubjectTicketNumber

    1 commit and branch inspected, 1 error detected

If we update the message to:

    Identify Jira issue references

    Identify Jira issue references in the commit body.

    Fix ABC-123

We get a hint:

    Hint[MessageTicketNumber]: The message body does not contain a ticket or issue number
    fd8cc74:7:1: Identify Jira issue references
      |
    5 | Fix ABC-123
    6 |
    7 | Fixes #123
      | ++++++++++ Consider adding a reference to a ticket or issue
      |
      = help: https://r.lintje.dev/r/MessageTicketNumber

    1 commit and branch inspected, 0 errors detected, 1 hint

This changes fixes this inconsistency by updating the `ISSUE_NUMBER_REFERENCE` regex to recognise Jira project codes too. This results in a slightly simpler Rules/SubjectTicketNumber implementation, as it now uses the same regex definition as Rules/MessageTicketNumber, but as a side-effect some previously valid (but poorly written) subjects are invalid now.

After this change, we get:

    1 commit and branch inspected, 0 errors detected


## To do

- [x] I agree to follow this project's [Code of Conduct](https://lintje.dev/code-of-conduct/).
- [ ] I've added an entry to the changelog in `CHANGELOG.md`.
    - This is only necessary if it's a change Lintje users need to know about. Internal refactors do not apply.

## Screenshots

See pasted examples in the description above.
